### PR TITLE
Feat: Add basic YAML-1.1 support for booleans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["yaml", "serde", "serialization"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/serde-yaml"
 rust-version = "1.58"
+default-features = ["yaml-1.1"]
 
 [dependencies]
 indexmap = { version = "1.9", features = ["std"] }
@@ -25,6 +26,9 @@ serde_derive = "1.0"
 
 [lib]
 doc-scrape-examples = false
+
+[features]
+"yaml-1.1"=[]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -339,6 +339,24 @@ where
                 Ok(ScalarStyle::SingleQuoted)
             }
 
+            #[cfg(feature = "yaml-1.1")]
+            fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E> {
+                // Pre YAML-1.2 we had to deal with the possibility of
+                // yes and no (and more) being interpreted as booleans.
+                //
+                // YAML-1.2 changes this behavior to more closely
+                // match other configuration languages.  Pre YAML-1.2
+                // code still exists in many places so this branch of
+                // logic exists to provide interoperability with those
+                // systems.
+                Ok(match _v {
+                    "yes" | "y" | "Y" | "YES" | "on" | "ON" | "off" | "OFF" | "no" | "n" | "N"
+                    | "NO" => ScalarStyle::SingleQuoted,
+                    _ => ScalarStyle::Any,
+                })
+            }
+
+            #[cfg(not(feature = "yaml-1.1"))]
             fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E> {
                 Ok(ScalarStyle::Any)
             }

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -189,6 +189,18 @@ fn test_vec() {
 }
 
 #[test]
+fn test_yes_no() {
+    let thing = vec!["x".to_owned(), "no".to_owned(), "yes".to_owned()];
+    let yaml = indoc! {"
+        - x
+        - 'no'
+        - 'yes'
+    "};
+
+    test_serde(&thing, yaml);
+}
+
+#[test]
 fn test_map() {
     let mut thing = BTreeMap::new();
     thing.insert("x".to_owned(), 1);


### PR DESCRIPTION
Pre YAML-1.2, words such as `yes`, `no`, `on` and `off` were regarded as boolean values. This move brings the language more in line with other languages, but can cause issues with integrations where older specs of YAML are used, where we have generated the documents using a newer spec.

Specifically looking at Kubernetes (e.g. 1.25) this issue can be seen when generating manifests as `no` strings in argument lists will be output as `no` rather than `'no'`.

This change brings back the ability to to output more in line with the pre YAML-1.2 spec.